### PR TITLE
Added path to zen gem in Ubuntu Linux (previously only the path on Mac was present)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,7 @@ css_dir = "css"
 sass_dir = "sass"
 images_dir = "images"
 javascripts_dir = "scripts"
-additional_import_paths = ["/Library/Ruby/Gems/2.0.0/gems/zen-grids-1.4/stylesheets"]
+additional_import_paths = ["/Library/Ruby/Gems/2.0.0/gems/zen-grids-1.4/stylesheets", "/var/lib/gems/2.0.0/gems/zen-grids-1.4/stylesheets"]
 
 output_style = :expanded
 environment = :development


### PR DESCRIPTION
The "additional_import_paths" points to additional ruby gems that we want to load; The path to the gem library is of course different between operating systems, so we should add the relevant paths for mac, linux and other operating systems. Linux distros could potentially hold the gems in different locations, so just add those as you require.