### PR TITLE
Added css class to keyword taxonomy links, and give it a nice green colour

### DIFF
--- a/sass/modules/_tag.scss
+++ b/sass/modules/_tag.scss
@@ -37,3 +37,11 @@
   color: #b3b3b3;
   font-size: .85em;
 }
+
+.taxonomy-keyword {
+  background-color: #007700;
+
+  &:hover {
+    background-color: #006600;
+  }
+}

--- a/templates/field/field--field-keyword.tpl.php
+++ b/templates/field/field--field-keyword.tpl.php
@@ -44,15 +44,10 @@
  * @ingroup themeable
  */
 ?>
-<!--
-THIS FILE IS NOT USED AND IS HERE AS A STARTING POINT FOR CUSTOMIZATION ONLY.
-See http://api.drupal.org/api/function/theme_field/7 for details.
-After copying this file to your theme's folder and customizing it, remove this
-HTML comment.
--->
+
 <?php if (!$label_hidden): ?>
   <?php print $label ?>:
 <?php endif; ?>
 <?php foreach ($items as $delta => $item): ?>
-  <a href="<?php print $item['#href']; ?>" title="<?php print $item['#title']; ?>" class="question--term"><?php print $item['#title']; ?></a>
+  <a href="<?php print $item['#href']; ?>" title="<?php print $item['#title']; ?>" class="question--term taxonomy-keyword"><?php print $item['#title']; ?></a>
 <?php endforeach; ?>


### PR DESCRIPTION
LOOP-17 would like the taxonomy bubbles to have different colours for the different categories. I picked the green colour myself, but that can of course be altered later.

Also removed the template comment, as the file is actually being used, contrary to the comment text.